### PR TITLE
openabf: revision 1

### DIFF
--- a/Formula/openabf.rb
+++ b/Formula/openabf.rb
@@ -4,6 +4,7 @@ class Openabf < Formula
   url "https://github.com/educelab/OpenABF/archive/refs/tags/v2.1.0-rc.1.tar.gz"
   sha256 "1ee4c74b8ea49684213539a28c3336d643797ca5a5a768c28c9219ed1ad1c040"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/educelab/OpenABF.git", branch: "develop"
 
   depends_on "cmake" => [:build, :test]


### PR DESCRIPTION
## Summary
- Force a bottle rebuild for openabf v2.1.0-rc.1.

## Why
PR #4 bumped openabf to v2.1.0-rc.1 but was merged via the normal GitHub merge button rather than the `brew pr-pull` flow, so no bottles were ever uploaded to `ghcr.io/v2/educelab/code/openabf` and the formula on `main` has no `bottle do` block. Users currently build from source.

Bumping `revision` forces `brew test-bot` to produce fresh bottles. Once `tests.yml` is green, `auto-label.yml` should tag this PR with `pr-pull`, which fires `publish.yml` to upload bottles to ghcr.io and rewrite the formula with a `bottle do` block.

## Test plan
- [ ] `brew test-bot` passes on all matrix OSes
- [ ] `auto-label.yml` adds the `pr-pull` label
- [ ] `publish.yml` runs and force-pushes a rewritten commit to `main` with a `bottle do` block
- [ ] `curl ... ghcr.io/v2/educelab/code/openabf/tags/list` includes `2.1.0-rc.1_1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)