### PR TITLE
ci: fix the bump → publish chain (auto-label PAT + drop homebrew/core tap)

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -19,6 +19,10 @@ jobs:
       - name: Add pr-pull label to passing bumper PRs
         uses: actions/github-script@v7
         with:
+          # GITHUB_TOKEN-applied labels do NOT trigger downstream
+          # workflows (GitHub's recursion guard). Use a PAT so the
+          # `labeled` event reaches publish.yml.
+          github-token: ${{ secrets.BUMP_PR_PAT }}
           script: |
             const run = context.payload.workflow_run;
             const prs = run.pull_requests || [];


### PR DESCRIPTION
## Summary
- `auto-label.yml`: use `BUMP_PR_PAT` so the applied label actually fires `publish.yml`.
- `publish.yml`: drop the obsolete `brew tap Homebrew/core` call.

## Why

**auto-label.yml** — GitHub's recursion guard means labels applied with `GITHUB_TOKEN` do not fire downstream workflows. `publish.yml` listens on `pull_request_target.labeled`, so without a PAT the chain stalls at the label step. Observed on #8.

**publish.yml** — modern Homebrew treats `homebrew/core` as an API-only tap and rejects `brew tap homebrew/core` without `--force`. `brew pr-pull` doesn't need it tapped. Observed on the first publish attempt for #8.

## Test plan
- [ ] After merge, manually remove and re-add the `pr-pull` label on #8 — `publish.yml` should fire and complete.
- [ ] Next bumper PR (cron or `repository_dispatch`) should complete the full chain end-to-end with no human intervention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)