### PR TITLE
publish: drop redundant brew tap Homebrew/core

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,8 +20,7 @@ jobs:
           HOMEBREW_GITHUB_PACKAGES_TOKEN: ${{ github.token }}
           HOMEBREW_GITHUB_PACKAGES_USER: ${{ github.actor }}
           PULL_REQUEST: ${{ github.event.pull_request.number }}
-        run: | 
-            brew tap Homebrew/core
+        run: |
             brew pr-pull --debug --tap="$GITHUB_REPOSITORY" "$PULL_REQUEST"
 
       - name: Push commits


### PR DESCRIPTION
## Summary
- Remove the `brew tap Homebrew/core` line from `publish.yml`.

## Why
Modern Homebrew treats `homebrew/core` as an API-only tap and errors on `brew tap homebrew/core` without `--force`. `brew pr-pull` does not need it tapped — it resolves formulae via the API. This was the second failure mode observed on #8 (the first being the GITHUB_TOKEN label-recursion guard, fixed by #9).

## Test plan
- [ ] After merge, manually remove and re-add the `pr-pull` label on #8 — `publish.yml` should now complete and upload bottles to ghcr.io.

🤖 Generated with [Claude Code](https://claude.com/claude-code)