### PR TITLE
registration-toolkit 1.7.0 (new formula)

### DIFF
--- a/Formula/registration-toolkit.rb
+++ b/Formula/registration-toolkit.rb
@@ -2,7 +2,7 @@ class RegistrationToolkit < Formula
   desc "C++ utilities for image-to-image and image-to-mesh registration"
   homepage "https://github.com/educelab/registration-toolkit"
   url "https://github.com/educelab/registration-toolkit/archive/refs/tags/v1.7.0.tar.gz"
-  sha256 "a0b47765243cb58689da102326484cf5893a862ce4703e84cdc952c0190d315d"
+  sha256 "7e9fdea836673b89cae563268fbe6d3dc31b8075c7c0419af5b7d846398154e3"
   license "GPL-3.0-or-later"
   head "https://github.com/educelab/registration-toolkit.git", branch: "develop"
 

--- a/Formula/registration-toolkit.rb
+++ b/Formula/registration-toolkit.rb
@@ -1,0 +1,29 @@
+class RegistrationToolkit < Formula
+  desc "C++ utilities for image-to-image and image-to-mesh registration"
+  homepage "https://github.com/educelab/registration-toolkit"
+  url "https://github.com/educelab/registration-toolkit/archive/refs/tags/v1.7.0.tar.gz"
+  sha256 "a0b47765243cb58689da102326484cf5893a862ce4703e84cdc952c0190d315d"
+  license "GPL-3.0-or-later"
+  head "https://github.com/educelab/registration-toolkit.git", branch: "develop"
+
+  depends_on "cmake" => :build
+  depends_on "boost"
+  depends_on "eigen"
+  depends_on "itk"
+  depends_on "opencv"
+  depends_on "spdlog"
+  depends_on "vtk"
+
+  def install
+    system "cmake", "-S", ".", "-B", "build",
+                    "-DRT_BUILD_DOCS=OFF",
+                    "-DRT_BUILD_TESTS=OFF",
+                    *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    assert_match "Usage", shell_output("#{bin}/rt_register --help 2>&1", 1)
+  end
+end


### PR DESCRIPTION
## Summary
- Add `Formula/registration-toolkit.rb` at v1.7.0.
- Pulls in CMake-built CLI utilities for image-to-image and image-to-mesh registration.

## Source
- Upstream: https://github.com/educelab/registration-toolkit
- Tag: [`v1.7.0`](https://github.com/educelab/registration-toolkit/releases) (no GitHub Release; tagged in the mirror)
- Deps mirror the upstream Brewfile: boost, eigen, itk, opencv, spdlog, vtk (+ cmake build-only).

## Notes
- License set to `GPL-3.0-or-later` per the upstream repo.
- Docs and tests disabled at build time to keep the bottle lean.
- `test do` just exercises `rt_register --help` since the binary uses Boost.ProgramOptions and exits 1 on help — `assert_match "Usage"` with allowed exit code 1.

## Test plan
- [ ] `brew test-bot` builds on ubuntu-latest, macos-14, macos-15
- [x] After #10 lands, label `pr-pull` (auto-label should handle it) and confirm bottles upload to ghcr.io
- [ ] `brew install educelab/code/registration-toolkit` works from a clean machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)