### PR TITLE
ci: build bottles on macos-26

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-14, macos-15]
+        os: [ubuntu-latest, macos-14, macos-15, macos-26]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Homebrew


### PR DESCRIPTION
## Summary
- Adds `macos-26` (Tahoe, arm64) to the `brew test-bot` matrix in `.github/workflows/tests.yml`
- We now build bottles for the four most recent supported platforms: `x86_64_linux`, `arm64_sonoma`, `arm64_sequoia`, `arm64_tahoe`

## Test plan
- [ ] Test-bot matrix runs green on all four runners
- [ ] Follow-up revision-bump PRs for `openabf` and `registration-toolkit` produce `arm64_tahoe` bottles

🤖 Generated with [Claude Code](https://claude.com/claude-code)