### PR TITLE
openabf: revision 2

### DIFF
--- a/Formula/openabf.rb
+++ b/Formula/openabf.rb
@@ -4,7 +4,7 @@ class Openabf < Formula
   url "https://github.com/educelab/OpenABF/archive/refs/tags/v2.1.0-rc.1.tar.gz"
   sha256 "1ee4c74b8ea49684213539a28c3336d643797ca5a5a768c28c9219ed1ad1c040"
   license "Apache-2.0"
-  revision 1
+  revision 2
   head "https://github.com/educelab/OpenABF.git", branch: "develop"
 
   bottle do


### PR DESCRIPTION
## Summary
- Bumps `openabf` revision from 1 to 2 to trigger a bottle rebuild
- Picks up the new `arm64_tahoe` (macOS 26) bottle once #13 lands

## Test plan
- [ ] Test-bot builds bottles on `ubuntu-latest`, `macos-14`, `macos-15`, `macos-26`
- [ ] `brew pr-pull` publishes all four bottles and updates the formula's `bottle do` block

🤖 Generated with [Claude Code](https://claude.com/claude-code)