### PR TITLE
registration-toolkit: revision 1

### DIFF
--- a/Formula/registration-toolkit.rb
+++ b/Formula/registration-toolkit.rb
@@ -4,6 +4,7 @@ class RegistrationToolkit < Formula
   url "https://github.com/educelab/registration-toolkit/archive/refs/tags/v1.8.0.tar.gz"
   sha256 "e45e139d26b0f286e40af688f949337db8de4d44af6da3b6536a82ccf270994c"
   license "GPL-3.0-or-later"
+  revision 1
   head "https://github.com/educelab/registration-toolkit.git", branch: "develop"
 
   bottle do


### PR DESCRIPTION
## Summary
- Adds `revision 1` to `registration-toolkit` to trigger a bottle rebuild
- Picks up the new `arm64_tahoe` (macOS 26) bottle once #13 lands

## Test plan
- [ ] Test-bot builds bottles on `ubuntu-latest`, `macos-14`, `macos-15`, `macos-26`
- [ ] `brew pr-pull` publishes all four bottles and updates the formula's `bottle do` block

🤖 Generated with [Claude Code](https://claude.com/claude-code)