### PR TITLE
gh: fix bump audit failing to resolve core formula dependencies

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -23,12 +23,16 @@ jobs:
     steps:
       - name: Set up Homebrew
         uses: Homebrew/actions/setup-homebrew@main
+        with:
+          core: true
 
       - name: Configure git user
         uses: Homebrew/actions/git-user-config@main
 
       - name: Bump packages
         uses: Homebrew/actions/bump-packages@main
+        env:
+          HOMEBREW_NO_INSTALL_FROM_API: "1"
         with:
           token: ${{ secrets.BUMP_PR_PAT }}
           fork: false


### PR DESCRIPTION
## Summary
- `setup-homebrew` explicitly sets `HOMEBREW_NO_INSTALL_FROM_API=` (empty, i.e. API mode) for all non-core-repo workflows via `$GITHUB_ENV`
- In API mode, `brew audit` cannot resolve core formula dependencies like `cmake` and `eigen`, causing `brew bump` to fail with "Can't find dependency"
- Fix: add `core: true` to `setup-homebrew` to clone homebrew-core with actual formula files, and set `HOMEBREW_NO_INSTALL_FROM_API: "1"` on the bump step so audit uses those files

## Test plan
- [ ] Trigger the bump workflow via `workflow_dispatch` and confirm it no longer fails on audit
- [ ] Confirm a bump PR is opened when a formula is outdated

🤖 Generated with [Claude Code](https://claude.com/claude-code)